### PR TITLE
Change CHANNEL to slack_channel and pull from env; fix bold chars

### DIFF
--- a/PostProcessors/Slacker.py
+++ b/PostProcessors/Slacker.py
@@ -57,6 +57,7 @@ class Slacker(Processor):
         was_imported = self.env.get("munki_repo_changed")
         munkiInfo = self.env.get("munki_info")
         webhook_url = self.env.get("webhook_url")
+        slack_channel = self.env.get("slack_channel")
 
         # Slack Custom Settings
         ICONEMOJI = ":ghost:"
@@ -70,8 +71,8 @@ class Slacker(Processor):
             pkginfo_path = self.env.get("munki_importer_summary_result")["data"]["pkginfo_path"]
             catalog = self.env.get("munki_importer_summary_result")["data"]["catalogs"]
             if name:
-                slack_text = "*New item added to repo:*\nTitle: *%s*\nVersion: *%s*\nCatalog: *%s\n*Pkg Path: *%s*\nPkginfo Path: *%s*" % (name, version, catalog, pkg_path, pkginfo_path)
-                slack_data = {'text': slack_text, 'channel': CHANNEL, 'icon_url': AUTOPKGICON, 'username': USERNAME}
+                slack_text = "*New item added to repo:*\nTitle: *%s*\nVersion: *%s*\nCatalog: *%s*\nPkg Path: *%s*\nPkginfo Path: *%s*" % (name, version, catalog, pkg_path, pkginfo_path)
+                slack_data = {'text': slack_text, 'channel': slack_channel, 'icon_url': AUTOPKGICON, 'username': USERNAME}
 
                 response = requests.post(
                 webhook_url, json=slack_data)


### PR DESCRIPTION
This PR will do two things:
1. Fixes the `*` characters for bold-ing parts of the Slack alert
2. Changes `CHANNEL` to `slack_channel` and defines it from an environment var. This change is a little more opinionated, but allows one to set this configuration variable from within an AutoPkg run-list `.plist` file.

With this change, one could then define the `slack_channel` in their AutoPkg run-list to set the Slack channel (to which notifications could be shipped) just like how `webhook_url` is populated.