### PR TITLE
Proposal to use subprocess + curl instead of requests library

### DIFF
--- a/PostProcessors/PostProcessors.recipe
+++ b/PostProcessors/PostProcessors.recipe
@@ -6,7 +6,7 @@
     <string>Recipe stub for any Processors in this directory.
     </string>
     <key>Identifier</key>
-    <string>com.github.notverypc.autopkg-recipes.postprocessors</string>
+    <string>com.github.coreyramirezgomez.autopkg-recipes.postprocessors</string>
     <key>Input</key>
     <dict/>
     <key>MinimumVersion</key>


### PR DESCRIPTION
Requests library requires pip or virtualenv, which both involve some extra steps to get working on a fresh system. My thought process here is that while using subprocess isn't _pretty_, it is less maintenance in terms of python environments.

Other changes include removal of USERNAME, AUTOPKGICON, and ICONEMOJI parameters since those are not configurable via the webhook data parameters (anymore?).